### PR TITLE
bugfix : redirect on init

### DIFF
--- a/global/abyssa.js
+++ b/global/abyssa.js
@@ -112,6 +112,8 @@ function Router(declarativeStates) {
     logger.log('Cancelling existing transition from {0} to {1}', transition.from, transition.to);
 
     transition.cancel();
+
+    firstTransition = false;
   }
 
   function startingTransition(fromState, toState) {
@@ -124,8 +126,7 @@ function Router(declarativeStates) {
   }
 
   function endingTransition(fromState, toState) {
-
-    if (!urlChanged) {
+    if (!urlChanged && !firstTransition) {
       logger.log('Updating URL: {0}', currentPathQuery);
       updateURLFromState(currentPathQuery, document.title, currentPathQuery);
     }
@@ -145,11 +146,9 @@ function Router(declarativeStates) {
     if (isHashMode()) {
       ignoreNextURLChange = true;
       location.hash = options.hashPrefix + url;
-    } else if (firstTransition) {
+    } else if (!initialized) {
       history.replaceState(state, title, url);
-    } else {
-      history.pushState(state, title, url);
-    }
+    } else history.pushState(state, title, url);
   }
 
   /*

--- a/global/abyssa.js
+++ b/global/abyssa.js
@@ -112,8 +112,6 @@ function Router(declarativeStates) {
     logger.log('Cancelling existing transition from {0} to {1}', transition.from, transition.to);
 
     transition.cancel();
-
-    firstTransition = false;
   }
 
   function startingTransition(fromState, toState) {
@@ -126,7 +124,8 @@ function Router(declarativeStates) {
   }
 
   function endingTransition(fromState, toState) {
-    if (!urlChanged && !firstTransition) {
+
+    if (!urlChanged) {
       logger.log('Updating URL: {0}', currentPathQuery);
       updateURLFromState(currentPathQuery, document.title, currentPathQuery);
     }
@@ -146,7 +145,11 @@ function Router(declarativeStates) {
     if (isHashMode()) {
       ignoreNextURLChange = true;
       location.hash = options.hashPrefix + url;
-    } else history.pushState(state, title, url);
+    } else if (firstTransition) {
+      history.replaceState(state, title, url);
+    } else {
+      history.pushState(state, title, url);
+    }
   }
 
   /*

--- a/src/Router.js
+++ b/src/Router.js
@@ -95,7 +95,6 @@ function Router(declarativeStates) {
 
     transition.cancel()
 
-    firstTransition = false
   }
 
   function startingTransition(fromState, toState) {
@@ -108,8 +107,8 @@ function Router(declarativeStates) {
   }
 
   function endingTransition(fromState, toState) {
-    if (!urlChanged && !firstTransition) {
-      logger.log('Updating URL: {0}', currentPathQuery)
+
+    if (!urlChanged) {
       updateURLFromState(currentPathQuery, document.title, currentPathQuery)
     }
 
@@ -126,11 +125,18 @@ function Router(declarativeStates) {
 
   function updateURLFromState(state, title, url) {
     if (isHashMode()) {
+      logger.log('Updating URL hash: {0}', currentPathQuery)
       ignoreNextURLChange = true
       location.hash = options.hashPrefix + url
     }
-    else
+    else if (firstTransition) {
+      logger.log('Updating URL state: {0}', currentPathQuery)
+      history.replaceState(state, title, url)
+    }
+    else {
+      logger.log('Pushing new URL state: {0}', currentPathQuery)
       history.pushState(state, title, url)
+    }
   }
 
   /*

--- a/src/Router.js
+++ b/src/Router.js
@@ -95,6 +95,7 @@ function Router(declarativeStates) {
 
     transition.cancel()
 
+    firstTransition = false
   }
 
   function startingTransition(fromState, toState) {
@@ -107,8 +108,8 @@ function Router(declarativeStates) {
   }
 
   function endingTransition(fromState, toState) {
-
-    if (!urlChanged) {
+    if (!urlChanged && !firstTransition) {
+      logger.log('Updating URL: {0}', currentPathQuery)
       updateURLFromState(currentPathQuery, document.title, currentPathQuery)
     }
 
@@ -125,18 +126,14 @@ function Router(declarativeStates) {
 
   function updateURLFromState(state, title, url) {
     if (isHashMode()) {
-      logger.log('Updating URL hash: {0}', currentPathQuery)
       ignoreNextURLChange = true
       location.hash = options.hashPrefix + url
-    }
-    else if (firstTransition) {
-      logger.log('Updating URL state: {0}', currentPathQuery)
+    } 
+    else if(!initialized) {
       history.replaceState(state, title, url)
     }
-    else {
-      logger.log('Pushing new URL state: {0}', currentPathQuery)
+    else
       history.pushState(state, title, url)
-    }
   }
 
   /*

--- a/test/integration-tests.js
+++ b/test/integration-tests.js
@@ -54,8 +54,6 @@ asyncTest('history.back() on inital redirect state', function() {
     router.transitionTo('/books')
     equal(router.urlPathQuery(), '/articles')
     equal(history.length, 2)
-
-    startLater()
   })
   .then(startLater)
 

--- a/test/integration-tests.js
+++ b/test/integration-tests.js
@@ -17,6 +17,51 @@ QUnit.testDone(function() {
 })
 
 
+asyncTest('history.back() on inital redirect state', function() {
+  // This test has to be first because it requires an empty hitory
+  equal(history.length, 1)
+
+  router = Router({
+
+    index: State('test', {
+      children: {
+        'integrationTests.html': State('integrationTests.html', {
+          enter: function() { router.transitionTo('/cart') }
+        }),
+      }
+    }),
+    articles: State('articles'),
+    books: State('books', {
+      enter: function() { router.transitionTo('/articles') }
+    }),
+    cart: State('cart'),
+
+  })
+
+  router.init()
+  equal(history.length, 1)
+
+  router.transitionTo('/cart')
+  equal(router.urlPathQuery(), '/cart')
+  equal(history.length, 1)
+
+  history.back()
+  Q.delay(60).then(function() {
+    equal(router.urlPathQuery(), '/cart')
+    equal(history.length, 1)
+  })
+  .then(function(){
+    router.transitionTo('/books')
+    equal(router.urlPathQuery(), '/articles')
+    equal(history.length, 2)
+
+    startLater()
+  })
+  .then(startLater)
+
+})
+
+
 asyncTest('Router initialization from initial URL', function() {
 
   changeURL('/initialState/36')
@@ -136,13 +181,36 @@ asyncTest('history.back() on the notFound state', function() {
 
   Q.delay(60).then(function() {
     // TODO: This assertion should pass ideally uncomment after the biggest refactorings
-    //equal(router.urlPathQuery(), '/notFound')
     equal(router.current().name, 'notFound')
   })
   .then(startLater)
 
 })
 
+asyncTest('history.back() when chained redirection', function() {
+
+  var api = Abyssa.api
+
+  const pageRedirect = { enter: function() { api.transitionTo('pageRedirectToPage1') }}
+  const pageRedirectToPage1 = { enter: function() { api.transitionTo('page1') }}
+
+  router = Router({
+    index: State('/test/integrationTests.html'),
+    page1: State('page1'),
+    pageRedirect: State('pageRedirect', pageRedirect),
+    pageRedirectToPage1: State('pageRedirectToPage1', pageRedirectToPage1)
+  }).init('index') //in the bug case the inialisation is init()
+
+  router.transitionTo('pageRedirect')
+  equal(router.current().name, 'page1')
+  history.back()
+
+  Q.delay(60).then(function() {
+    equal(router.current().name, 'index')
+  })
+  .then(startLater)
+
+})
 
 asyncTest('hash mode switched on', function() {
 
@@ -267,7 +335,6 @@ asyncTest('customize hashbang', function() {
   }
 
 })
-
 
 test('replaceParams', function() {
   var router = Abyssa.api

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -705,7 +705,7 @@ test('params should be decoded automatically', function() {
 })
 
 
-test('redirect', function() {
+test('Init with a redirect', function() {
   var oldRouteChildEntered
   var oldRouteExited
   var newRouteEntered
@@ -725,11 +725,45 @@ test('redirect', function() {
 
   })
 
-  pushedStates.length = 0
+  pushedStates.length = 1
 
   router.init('oldRoute.oldRouteChild')
 
-  equal(pushedStates.length, 1, 'A redirection should push a single history entry')
+  equal(pushedStates.length, 1, 'Initiating with a redirection should not push a new state in history')
+
+  ok(!oldRouteExited, 'The state was not properly entered as it redirected immediately. Therefore, it should not exit.')
+  ok(!oldRouteChildEntered, 'A child state of a redirected route should not be entered')
+  ok(newRouteEntered)
+})
+
+
+test('redirect', function() {
+  var oldRouteChildEntered
+  var oldRouteExited
+  var newRouteEntered
+
+  var router = Router({
+    init: State('init'),
+
+    oldRoute: State('oldRoute', {
+      enter: function() {
+        router.transitionTo('newRoute')
+      },
+      exit: function() { oldRouteExited = true }
+    }, {
+      oldRouteChild: State('child', { enter: function() { oldRouteChildEntered = true } })
+    }),
+
+    newRoute: State('newRoute', { enter: function() { newRouteEntered = true } })
+
+  })
+
+  pushedStates.length = 1
+
+  router.init('init')
+  router.transitionTo('oldRoute.oldRouteChild')
+
+  equal(pushedStates.length, 2, 'A redirection should push a single history entry')
 
   ok(!oldRouteExited, 'The state was not properly entered as it redirected immediately. Therefore, it should not exit.')
   ok(!oldRouteChildEntered, 'A child state of a redirected route should not be entered')
@@ -1211,9 +1245,17 @@ test('The public fullName of a _default_ state is the same as its parent', funct
 })
 
 
-const pushedStates = []
+const pushedStates = [{}]
 function stubHistory() {
   window.history.pushState = function(state, title, url) {
+    pushedStates.push({
+      state: state,
+      title: title,
+      url: url
+    })
+  }
+  window.history.replaceState = function(state, title, url) {
+    pushedStates.pop()
     pushedStates.push({
       state: state,
       title: title,

--- a/test/unit-tests.js
+++ b/test/unit-tests.js
@@ -3,6 +3,7 @@ Router = Abyssa.Router
 State  = Abyssa.State
 
 //Router.enableLogs()
+
 stubHistory()
 
 QUnit.testDone(function() {
@@ -724,9 +725,6 @@ test('Init with a redirect', function() {
     newRoute: State('newRoute', { enter: function() { newRouteEntered = true } })
 
   })
-
-  pushedStates.length = 1
-
   router.init('oldRoute.oldRouteChild')
 
   equal(pushedStates.length, 1, 'Initiating with a redirection should not push a new state in history')
@@ -757,8 +755,6 @@ test('redirect', function() {
     newRoute: State('newRoute', { enter: function() { newRouteEntered = true } })
 
   })
-
-  pushedStates.length = 1
 
   router.init('init')
   router.transitionTo('oldRoute.oldRouteChild')
@@ -1245,8 +1241,13 @@ test('The public fullName of a _default_ state is the same as its parent', funct
 })
 
 
-const pushedStates = [{}]
+const pushedStates = [{}] //contains initial state in history
+
 function stubHistory() {
+  QUnit.testStart(function(){
+    pushedStates.splice(0, pushedStates.length, {})
+  })  
+  
   window.history.pushState = function(state, title, url) {
     pushedStates.push({
       state: state,


### PR DESCRIPTION
Currently, if a redirect happens during initialization, we end up with two entries in history (first entry when the browser open the page, second from the redirection). 

When the user goes back in the history, il goes back to the first entry which redirects to the second one :-(, so `history.back()` becomes unusable unless we go back 2 states at once.

This PR changes this behaviour : 
 - if we are during initialization, `history.replaceState` is called
 - otherwise, same as usual

We added the corresponding tests.